### PR TITLE
Refactor mod slips

### DIFF
--- a/mod_slips/Dockerfile
+++ b/mod_slips/Dockerfile
@@ -5,5 +5,6 @@ ADD requirements.txt /code/
 RUN cd /StratosphereLinuxIPS/ && git checkout develop
 RUN git pull
 WORKDIR /code
+RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 CMD ["python3", "mod_slips.py"]

--- a/mod_slips/mod_slips.py
+++ b/mod_slips/mod_slips.py
@@ -48,9 +48,6 @@ def process_profile_traffic(profile_name, PATH):
             process = subprocess.run(args, cwd="/StratosphereLinuxIPS",
                                        stdout=subprocess.PIPE, timeout=86400)
 
-            # Wait for Slips IDS to finish processing
-            process.wait()
-
         # When all captures are processed, return True
         return True
     except Exception as err:

--- a/mod_slips/mod_slips.py
+++ b/mod_slips/mod_slips.py
@@ -13,6 +13,7 @@ from common.database import redis_connect_to_db
 from common.database import redis_create_subscriber
 from common.database import redis_subscribe_to_channel
 
+
 def process_profile_traffic(profile_name, PATH):
     """ Function to process the traffic for a given profile. """
     VALID_CAPTURE = False
@@ -41,8 +42,9 @@ def process_profile_traffic(profile_name, PATH):
         logging.info(f'Exception in process_profile_traffic: {err}')
         return False
 
+
 if __name__ == '__main__':
-    #Read configuration
+    # Read configuration
     config = configparser.ConfigParser()
     config.read('config/config.ini')
 

--- a/mod_slips/mod_slips.py
+++ b/mod_slips/mod_slips.py
@@ -28,12 +28,12 @@ def process_profile_traffic(profile_name,PATH):
 
             # If capture is not empty: process it
             if capture_size > 25:
-                VALID_CAPTURE=True
+                VALID_CAPTURE = True
                 # Run Slips here
-                OUTPUT=f'{PATH}/{profile_name}/slips_{capture_file}/'
-                FILENAME=f'{PATH}/{profile_name}/{capture_file}'
-                CONFIGURATION='/StratosphereLinuxIPS/aivpn_slips.conf'
-                args=['/StratosphereLinuxIPS/slips.py','-c',CONFIGURATION,'-f',FILENAME,'-o',OUTPUT]
+                OUTPUT = f'{PATH}/{profile_name}/slips_{capture_file}/'
+                FILENAME = f'{PATH}/{profile_name}/{capture_file}'
+                CONFIGURATION = '/StratosphereLinuxIPS/aivpn_slips.conf'
+                args = ['/StratosphereLinuxIPS/slips.py','-c',CONFIGURATION,'-f',FILENAME,'-o',OUTPUT]
                 process = subprocess.Popen(args,cwd="/StratosphereLinuxIPS", stdout=subprocess.PIPE)
                 process.wait()
                 return VALID_CAPTURE
@@ -100,12 +100,12 @@ if __name__ == '__main__':
                     logging.info(f'Status of the processing of profile {profile_name}: {status}')
                     if not status:
                         logging.info('An error occurred processing the capture with Slips')
-                        message=f'slips_false:{profile_name}'
+                        message = f'slips_false:{profile_name}'
                         redis_client.publish('slips_processing',message)
                         continue
                     if status:
                         logging.info('Processing of associated captures completed')
-                        message=f'slips_true:{profile_name}'
+                        message = f'slips_true:{profile_name}'
                         redis_client.publish('slips_processing',message)
 
         redis_client.publish('services_status', 'MOD_SLIPS:offline')

--- a/mod_slips/mod_slips.py
+++ b/mod_slips/mod_slips.py
@@ -17,16 +17,19 @@ from common.database import redis_subscribe_to_channel
 
 def process_profile_traffic(profile_name, PATH):
     """
-    Function to process the traffic for a given profile.
+    Process the traffic for a given profile with Slips IDS.
     """
 
     VALID_CAPTURE = False
     try:
         # Find all pcaps for the profile and process them
+        # Go to profile directory
         os.chdir(f'{PATH}/{profile_name}')
 
+        # Find all pcaps for the profile and process them
         for capture_file in glob.glob("*.pcap"):
             os.mkdir(f'{PATH}/{profile_name}/slips_{capture_file}')
+            # Check size of packet capture
             capture_size = os.stat(capture_file).st_size
             logging.info(f'Processing file: {capture_file} ({capture_size} b)')
 
@@ -44,6 +47,12 @@ def process_profile_traffic(profile_name, PATH):
                 process.wait()
                 return VALID_CAPTURE
         return False
+            # If capture is empty: do not process it
+            # If capture is not empty, process it with Slips IDS
+            # Create Slips working directory
+            # Run Slips as subprocess
+            # Wait for Slips IDS to finish processing
+        # When all captures are processed, return True
     except Exception as err:
         logging.info(f'Exception in process_profile_traffic: {err}')
         return False

--- a/mod_slips/mod_slips.py
+++ b/mod_slips/mod_slips.py
@@ -6,13 +6,12 @@
 import os
 import sys
 import glob
-import json
-import redis
 import logging
 import subprocess
 import configparser
-from common.database import *
-from collections import Counter
+from common.database import redis_connect_to_db
+from common.database import redis_create_subscriber
+from common.database import redis_subscribe_to_channel
 
 def process_profile_traffic(profile_name,PATH):
     """ Function to process the traffic for a given profile. """

--- a/mod_slips/requirements.txt
+++ b/mod_slips/requirements.txt
@@ -1,2 +1,1 @@
-redis
 psutil

--- a/mod_slips/slips_configuration.conf
+++ b/mod_slips/slips_configuration.conf
@@ -72,7 +72,7 @@ create_log_files = yes
 delete_zeek_files = no
 
 # Store zeek files in the output dir. Only yes or no
-store_a_copy_of_zeek_files = no
+store_a_copy_of_zeek_files = yes
 
 # Create a metadata dir output/metadata/ that has a copy of slips.conf, whitelist file, current commit and date
 # available options are yes or no


### PR DESCRIPTION
- PEP8 compatibility
- Save Zeek files to the output directory
- Use subprocess run() instead of Popen
- Remove Popen wait now we use run()
- Upgrade pip to the latest version