### PR TITLE
Store Zeek logs in the output

### DIFF
--- a/mod_slips/slips_configuration.conf
+++ b/mod_slips/slips_configuration.conf
@@ -72,7 +72,7 @@ create_log_files = yes
 delete_zeek_files = no
 
 # Store zeek files in the output dir. Only yes or no
-store_a_copy_of_zeek_files = no
+store_a_copy_of_zeek_files = yes
 
 # Create a metadata dir output/metadata/ that has a copy of slips.conf, whitelist file, current commit and date
 # available options are yes or no


### PR DESCRIPTION
Most changes were implemented on the fixing of Slips. Not much to do on the reporting side right now.