### PR TITLE
Update WireGuard config's SERVER_PUBLIC_URL to UDP

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -51,7 +51,7 @@ NETWORK_CIDR = 192.168.254.0/24
 DNS_SERVER=172.16.1.2
 
 [WIREGUARD]
-SERVER_PUBLIC_URL = tcp://example-server.com
+SERVER_PUBLIC_URL = udp://example-server.com
 PKI_ADDRESS = vpn.example-server.com
 NETWORK_CIDR = 192.168.254.0/24
 

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -52,6 +52,8 @@ DNS_SERVER=172.16.1.2
 
 [WIREGUARD]
 SERVER_PUBLIC_URL = udp://example-server.com
+# Switch to this for having TCP instead of UDP:
+# SERVER_PUBLIC_URL = tcp://example-server.com
 PKI_ADDRESS = vpn.example-server.com
 NETWORK_CIDR = 192.168.254.0/24
 


### PR DESCRIPTION
closes #48 
This updates the SERVER_PUBLIC_URL configuration for the WireGuard VPN setup from TCP to UDP in the `config/config.ini.example`. 

> WireGuard explicitly does not support tunneling over TCP, due to the classically terrible network performance of tunneling TCP-over-TCP.

Source : https://www.wireguard.com/known-limitations/