### PR TITLE
Bugfix prevent error for unspecified CLI parameters

### DIFF
--- a/aivpn.py
+++ b/aivpn.py
@@ -311,4 +311,9 @@ if __name__ == '__main__':
         logging.info(f'Unable to connect to Redis ({args.redis}): {err}')
         sys.exit(-1)
 
+    # Ensure action defined
+    if 'cli_action' not in locals():
+        parser.print_help()
+        sys.exit(1)
+        
     cli_action(redis_client,params)


### PR DESCRIPTION
Closes #35 

This PR introduces a check to prevent the `NameError: name 'cli_action' is not defined` that occurs when running `python3 aivpn.py --redis "x.x.x.x" audit` without specifying the required parameters. This fix ensures that the aivpn.py now checks if the cli_action variable is present in the local scope before proceeding. If not found, the program gracefully exits by printing a help message and exiting with a status code of 1.